### PR TITLE
Removed KPBS scrap metal container

### DIFF
--- a/GameData/SimpleConstruction/Patches/SC/KPBS.cfg
+++ b/GameData/SimpleConstruction/Patches/SC/KPBS.cfg
@@ -1,4 +1,5 @@
 -PART[KKAOSS_MetalOreDrill]:AFTER[PlanetarySurfaceStructures]{}
+-PART[KKAOSS_ScrapMetal]:AFTER[PlanetarySurfaceStructures]{}
 
 @PART[KKAOSS_Storage_Metal]:AFTER[PlanetarySurfaceStructures]
 {


### PR DESCRIPTION
KPBS' scrap metal container (KKAOSS_ScrapMetal) is not needed for usage with Simple Construction because scrap metal as a feature has been removed